### PR TITLE
Fix UTF-8 encoding on demo page 

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="UTF-8">
 <script src="warrenbuf.js"></script>
 <style>
   /************* "Atomic CSS" classes for Boxes *************/
@@ -824,7 +825,7 @@
       for (let row = 0; row < CONWAY_ROWS; row++) {
         let line = '';
         for (let col = 0; col < CONWAY_COLS; col++) {
-          line += conwayGrid[row][col] ? 'X' : '.';
+          line += conwayGrid[row][col] ? '■' : '.';
         }
         lines.push(line);
       }


### PR DESCRIPTION
Previously, UTF-8 characters were being rendered cryptically on the demo page. We were missing a meta tag.

This PR also includes a new example in the gallery which serves as a litmus test of the UTF-8 issue 

Before fix:
<img width="646" height="452" alt="Screenshot 2025-10-09 at 1 09 00 AM" src="https://github.com/user-attachments/assets/039c2c24-42f9-4160-8879-486f5053ea8e" />

After:

<img width="636" height="544" alt="Screenshot 2025-10-09 at 1 10 11 AM" src="https://github.com/user-attachments/assets/9a9895db-08ca-40c6-8158-b2409ec1be1b" />
