### PR TITLE
fix: selection not shown 

### DIFF
--- a/dev/changelog.txt
+++ b/dev/changelog.txt
@@ -1,4 +1,8 @@
-* Project Devlog 
+* Project Devlog
+
+** 7.7.2-alpha.1 [2025-12-19]  gz+min: 4.71 KB (+0.01), min: 13.84 KB (0)
+*** fix
+- add missing height for .wb-selection in CSS (was removed when delegating lineHeight to CSS)
 
 ** 7.7.1-alpha.1 [2025-12-18]  gz+min: 4.75 KB (+0.01), min: 13.86 KB (-0.11)
 *** refactor(config)

--- a/style.css
+++ b/style.css
@@ -1,6 +1,6 @@
 /**
  * Buffee Editor - Required Styles
- * @version 7.7.1-alpha.1
+ * @version 7.7.2-alpha.1
  *
  * This stylesheet contains the essential structural CSS for Buffee.
  * Colors are intentionally omitted - define them at point of usage.
@@ -119,7 +119,7 @@
   z-index: 400; /** config */
 }
 
-.wb .wb-cursor { height: var(--wb-cell); }
+.wb .wb-cursor, .wb .wb-selection { height: var(--wb-cell); }
 .wb .wb-cursor, .wb .wb-gutter, .wb .wb-lines, .wb .wb-selection {
   font-size: var(--wb-cell); line-height: var(--wb-cell);
 }


### PR DESCRIPTION
issue: selection wasn't been rendered.

**symptom 1:** The selection always overlap the cursor and their style blends. As a consequence of this bug, we saw the raw cursor without the selection. the color was different.

**symptom 2:** when creating selection, it was not visible 

**Culprit:** Regression caused at ae68773


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restores selection rendering by giving `.wb-selection` a height equal to `var(--wb-cell)` and updates version metadata.
> 
> - **CSS**:
>   - Apply `height: var(--wb-cell);` to both `.wb .wb-cursor` and `.wb .wb-selection` to ensure selection renders correctly.
>   - Bump stylesheet `@version` to `7.7.2-alpha.1`.
> - **Changelog**:
>   - Add `7.7.2-alpha.1` entry noting the selection height fix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8cd69816e11d787c92e726b48ef1a154957823a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->