### PR TITLE
simplify getting-started

### DIFF
--- a/API.md
+++ b/API.md
@@ -10,53 +10,11 @@ Include the JavaScript function `Buffee`
 
 ## Required HTML Structure
 
-Layout the HTML for the editor. 
-```html
-<blockquote class="wb no-select" tabindex="0" id="editor">
-  <textarea class="wb-clipboard-bridge" aria-hidden="true"></textarea>
-  <div style="display: flex;">
-    <div class="wb-gutter"></div>
-    <div class="wb-lines"></div>
-  </div>
-  <div class="wb-status" style="display: flex; justify-content: space-between;">
-    <div class="wb-status-left"><span class="wb-linecount"></span></div>
-    <div class="wb-status-right">
-      <span class="wb-coordinate"></span>
-      <span>|</span>
-      <span class="wb-indentation"></span>
-    </div>
-  </div>
-</blockquote>
-```
+See `template.html`
 
 ## Include the referenced CSSS
 
-```css
-.wb {
-  background-color: #282C34;
-  color: #B2B2B2;
-  position: relative;
-  outline: none;
-  font-family: 'Monaco', 'Menlo', 'Consolas', monospace;
-}
-.no-select { user-select: none; }
-.wb-clipboard-bridge {
-  position: fixed; left: 0; top: 1px;
-  width: 0; height: 1px; opacity: 0; pointer-events: none;
-}
-.wb .wb-lines pre::before { content: "\200B"; }
-.wb .wb-lines pre { margin: 0; overflow: hidden; }
-.wb .wb-selection {
-  background-color: #EDAD10;
-  position: absolute;
-  mix-blend-mode: difference;
-}
-.wb .wb-cursor {
-  background-color: #FF6B6B;
-  mix-blend-mode: difference;
-}
-.wb .wb-status span { padding-right: 4px; }
-```
+See `style.css`
 
 ## Sizing the Editor
 

--- a/claude.md
+++ b/claude.md
@@ -2,7 +2,7 @@
 
 ## Required HTML Structure
 
-See `getting-started.html` for the required HTML structure. Missing any element will cause `Cannot set properties of null` errors.
+See `template.html` for the required HTML structure. Missing any element will cause `Cannot set properties of null` errors.
 
 ## Cursor Model (Vim-style)
 

--- a/getting-started.html
+++ b/getting-started.html
@@ -33,44 +33,33 @@
 &lt;/style&gt;</pre>
 
   <h2>2. Required HTML Structure</h2>
-  <p><strong>All elements required.</strong> Missing any causes errors.</p>
+  <p>Add HTML outlined in <a href="template.html">template.html</a>.</p>
   <pre>&lt;blockquote class="wb no-select" tabindex="0" id="editor"&gt;
   &lt;textarea class="wb-clipboard-bridge" aria-hidden="true"&gt;&lt;/textarea&gt;
   &lt;div class="wb-content"&gt;
     &lt;div class="wb-gutter"&gt;&lt;/div&gt;
-    &lt;div class="wb-lines"&gt;&lt;/div&gt;
+    &lt;div class="wb-lines"&gt;
+        &lt;div class="wb-layer-text"&gt;&lt;/div&gt;
+        &lt;div class="wb-layer-elements"&gt;&lt;/div&gt;
+        &lt;div class="wb-cursor"&gt;&lt;/div&gt;
+    &lt;/div&gt;
   &lt;/div&gt;
-  &lt;div class="wb-status" style="display: flex; justify-content: space-between;"&gt;
+  &lt;div class="wb-status"&gt;
     &lt;div class="wb-status-left"&gt;&lt;span class="wb-linecount"&gt;&lt;/span&gt;&lt;/div&gt;
     &lt;div class="wb-status-right"&gt;
-      &lt;span class="wb-coordinate"&gt;&lt;/span&gt;
+      &lt;span class="wb-coordinate"&gt;&lt;/span&gt;|
       &lt;span class="wb-indentation"&gt;&lt;/span&gt;
     &lt;/div&gt;
   &lt;/div&gt;
 &lt;/blockquote&gt;</pre>
 
-  <p>Checklist:</p>
-  <ul>
-    <li><label><input type="checkbox"> <code>.wb</code> - container</label></li>
-    <li><label><input type="checkbox"> <code>.wb-clipboard-bridge</code> - textarea</label></li>
-    <li><label><input type="checkbox"> <code>.wb-content</code> - content area (gutter + lines)</label></li>
-    <li><label><input type="checkbox"> <code>.wb-gutter</code> - line numbers</label></li>
-    <li><label><input type="checkbox"> <code>.wb-lines</code> - text content</label></li>
-    <li><label><input type="checkbox"> <code>.wb-status</code> - status bar</label></li>
-    <li><label><input type="checkbox"> <code>.wb-status-left</code> - left section</label></li>
-    <li><label><input type="checkbox"> <code>.wb-status-right</code> - right section</label></li>
-    <li><label><input type="checkbox"> <code>.wb-linecount</code></label></li>
-    <li><label><input type="checkbox"> <code>.wb-coordinate</code></label></li>
-    <li><label><input type="checkbox"> <code>.wb-indentation</code></label></li>
-  </ul>
 
-  <h2>3. Include the Script</h2>
-  <p>Include the function <code>Buffee</code> found in <a href="buffee.js">Buffee.js</a></p>
-  <pre>&lt;script src="buffee.js"&gt;&lt;/script&gt;</pre>
-  <p>Or minified:</p>
-  <pre>&lt;script src="dist.buffee.min.js"&gt;&lt;/script&gt;</pre>
+  <h2>3. Include the Buffee</h2>
+  <p>Buffee is just a JavaScript function made globally available when you include <a href="dist/buffee.min.js">dist/buffee.min.js</a></p>
+  <pre>&lt;script src="dist/buffee.min.js"&gt;&lt;/script&gt;</pre>
 
   <h2>4. Initialize</h2>
+  Instantiate Buffee which binds to the HTML element.
   <pre>const editor = new Buffee(document.getElementById('editor'))
 editor.Model.lines = ["Hello, World!"]
 editor._internals.render(true);

--- a/index.html
+++ b/index.html
@@ -64,9 +64,7 @@
               </div>
           </div>
           <div class="wb-status">
-              <div class="wb-status-left">
-                  <span class="wb-linecount"></span>
-              </div>
+              <div class="wb-status-left"><span class="wb-linecount"></span></div>
               <div class="wb-status-right">
                   <span class="wb-coordinate"></span>|
                   <span class="wb-indentation"></span>

--- a/readme.md
+++ b/readme.md
@@ -69,7 +69,7 @@ see [themes](https://varrockbank.github.io/buffee/themes.html) for inspiration.
 Editor instances bind to DOM node with this structure:
 
 ```html
-<blockquote class="wb no-select" tabindex="0" id="editor" style="">
+<blockquote class="wb no-select" tabindex="0" id="editor">
   <textarea class="wb-clipboard-bridge" aria-hidden="true"></textarea>
   <div class="wb-content">
     <div class="wb-gutter"></div>

--- a/template.html
+++ b/template.html
@@ -8,7 +8,7 @@
         <div class="wb-cursor"></div>
     </div>
   </div>
-  <div class="wb-status" style="display: flex; justify-content: space-between;">
+  <div class="wb-status">
     <div class="wb-status-left"><span class="wb-linecount"></span></div>
     <div class="wb-status-right">
       <span class="wb-coordinate"></span>|


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Simplifies docs by referencing a shared HTML/CSS template, updates example HTML structure (layers, status), and switches script includes to dist path.
> 
> - **Docs**
>   - **Getting Started (`getting-started.html`)**: Replace verbose HTML checklist with link to `template.html`; update example structure to include `wb-layer-*` and inline `wb-cursor`; simplify `.wb-status` markup; switch script include to `dist/buffee.min.js`; add brief init note.
>   - **API/Guides**: In `API.md` and `claude.md`, replace embedded HTML/CSS snippets with references to `template.html` and `style.css`.
>   - **Templates/Examples**: Remove inline styles and normalize status markup in `template.html`, `index.html`, and `readme.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb3cd682726efbdf6ca9f79e85d698b3ca88492a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->